### PR TITLE
Include annotations in output

### DIFF
--- a/commands/eval/main.py
+++ b/commands/eval/main.py
@@ -80,6 +80,7 @@ def main(
     verbose: bool,
     max_checked_annots: int,
     show_line_numbers: bool,
+    annotation_info_keys: List[str],
 ):
 
     curr_dir = os.path.dirname(os.path.abspath(__file__))
@@ -184,6 +185,7 @@ def main(
             comparisons is None or "score_snv" in comparisons,
             comparisons is None or "annotation_snv" in comparisons,
             show_line_numbers,
+            annotation_info_keys,
         )
 
     if (
@@ -227,6 +229,7 @@ def main(
             comparisons is None or "score_sv" in comparisons,
             comparisons is None or "annotation_sv" in comparisons,
             show_line_numbers,
+            annotation_info_keys,
         )
 
     if comparisons is None or "yaml" in comparisons:
@@ -429,6 +432,7 @@ def add_arguments(parser: argparse.ArgumentParser):
         action="store_true",
         help="Show line numbers from original VCFs in output",
     )
+    parser.add_argument("--annotations", help="INFO keys to include in output tables")
 
 
 def main_wrapper(args: argparse.Namespace):
@@ -445,6 +449,7 @@ def main_wrapper(args: argparse.Namespace):
         args.verbose,
         args.max_checked_annots,
         args.show_line_numbers,
+        args.annotations.split(",")
     )
 
 

--- a/commands/run/file_helpers.py
+++ b/commands/run/file_helpers.py
@@ -76,15 +76,15 @@ def get_single_csv(
     stub_run: bool,
 ):
     case_id = run_type_settings["case"]
-    case = config[case_id]
+    case_conf = config[case_id]
 
     # Replace real data with dummy files in stub run to avoid scratching
     if stub_run:
         stub_case = config["settings"]
         for key in stub_case:
-            case[key] = stub_case[key]
+            case_conf[key] = stub_case[key]
 
-    case = parse_case(dict(case), start_data, is_trio=False)
+    case = parse_case(dict(case_conf), start_data, is_trio=False)
 
     if not Path(case.read1).exists() or not Path(case.read2).exists():
         raise FileNotFoundError(f"One or both files missing: {case.read1} {case.read2}")

--- a/commands/vcf/main.py
+++ b/commands/vcf/main.py
@@ -63,7 +63,7 @@ def main(
         do_score_check,
         do_annot_check,
         show_line_numbers,
-        annotations if annotations is not None else [],
+        annotations,
     )
 
 
@@ -112,7 +112,6 @@ def add_arguments(parser: argparse.ArgumentParser):
         default=10,
         help="Limit the number of entries printed to STDOUT (all entries are written to results folder)",
     )
-
     parser.add_argument(
         "--annotations", help="Comma separated additional annotations to retain in output"
     )

--- a/commands/vcf/main.py
+++ b/commands/vcf/main.py
@@ -22,8 +22,7 @@ def main(
     run_id1: Optional[str],
     run_id2: Optional[str],
     results: Optional[Path],
-    filter_key: str,
-    filter_list: Path,
+    annotations: List[str],
 ):
     show_line_numbers = True
     out_path_presence = results / "presence.txt" if results else None
@@ -59,6 +58,7 @@ def main(
         do_score_check,
         do_annot_check,
         show_line_numbers,
+        annotations if annotations is not None else [],
     )
 
 
@@ -74,8 +74,7 @@ def main_wrapper(args: argparse.Namespace):
         args.id1,
         args.id2,
         args.results if args.results is not None else None,
-        args.filter_key,
-        args.filter_list
+        args.annotations.split(",") if args.annotations is not None else [],
     )
 
 
@@ -109,8 +108,9 @@ def add_arguments(parser: argparse.ArgumentParser):
         help="Limit the number of entries printed to STDOUT (all entries are written to results folder)",
     )
 
-    parser.add_argument("--filter_key", help="INFO field key used for filtering")
-    parser.add_argument("--filter_list", type=Path, help="File containing entries to filter on")
+    parser.add_argument(
+        "--annotations", help="Comma separated additional annotations to retain in output"
+    )
 
 
 if __name__ == "__main__":

--- a/commands/vcf/main.py
+++ b/commands/vcf/main.py
@@ -25,6 +25,11 @@ def main(
     annotations: List[str],
 ):
     show_line_numbers = True
+
+    if results is not None:
+        if not results.exists():
+            results.mkdir(parents=True)
+
     out_path_presence = results / "presence.txt" if results else None
 
     if run_id1 is None:
@@ -114,7 +119,7 @@ def add_arguments(parser: argparse.ArgumentParser):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     add_arguments(parser)
     args = parser.parse_args()
     main_wrapper(args)

--- a/commands/vcf/main.py
+++ b/commands/vcf/main.py
@@ -1,7 +1,7 @@
 import argparse
 from pathlib import Path
 import logging
-from typing import Optional
+from typing import List, Optional
 
 from shared.vcf.main_functions import (
     variant_comparisons,
@@ -22,6 +22,8 @@ def main(
     run_id1: Optional[str],
     run_id2: Optional[str],
     results: Optional[Path],
+    filter_key: str,
+    filter_list: Path,
 ):
     show_line_numbers = True
     out_path_presence = results / "presence.txt" if results else None
@@ -61,30 +63,33 @@ def main(
 
 
 def main_wrapper(args: argparse.Namespace):
+
     main(
-        Path(args.vcf1),
-        Path(args.vcf2),
+        args.vcf1,
+        args.vcf2,
         args.is_sv,
         args.score_threshold,
         args.max_checked_annots,
         args.max_display,
         args.id1,
         args.id2,
-        Path(args.results) if args.results is not None else None,
+        args.results if args.results is not None else None,
+        args.filter_key,
+        args.filter_list
     )
 
 
 def add_arguments(parser: argparse.ArgumentParser):
     parser.add_argument(
-        "--vcf1", "-1", required=True, help="VCF to compare in .vcf or .vcf.gz format"
+        "--vcf1", "-1", required=True, type=Path, help="VCF to compare in .vcf or .vcf.gz format"
     )
     parser.add_argument(
-        "--vcf2", "-2", required=True, help="VCF to compare in .vcf or .vcf.gz format"
+        "--vcf2", "-2", required=True, type=Path, help="VCF to compare in .vcf or .vcf.gz format"
     )
     parser.add_argument("--id1", help="Optional run ID for first vcf")
     parser.add_argument("--id2", help="Optional run ID for second vcf")
     parser.add_argument("--is_sv", action="store_true", help="Process VCF in SV mode")
-    parser.add_argument("--results", help="Optional results folder")
+    parser.add_argument("--results", type=Path, help="Optional results folder")
     parser.add_argument(
         "--score_threshold",
         type=int,
@@ -103,6 +108,9 @@ def add_arguments(parser: argparse.ArgumentParser):
         default=10,
         help="Limit the number of entries printed to STDOUT (all entries are written to results folder)",
     )
+
+    parser.add_argument("--filter_key", help="INFO field key used for filtering")
+    parser.add_argument("--filter_list", type=Path, help="File containing entries to filter on")
 
 
 if __name__ == "__main__":

--- a/commands/vcf/main.py
+++ b/commands/vcf/main.py
@@ -119,7 +119,7 @@ def add_arguments(parser: argparse.ArgumentParser):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser = argparse.ArgumentParser()
     add_arguments(parser)
     args = parser.parse_args()
     main_wrapper(args)

--- a/main.py
+++ b/main.py
@@ -25,23 +25,38 @@ def main():
     elif args.subcommand == "vcf":
         vcf_main_wrapper(args)
     else:
-        raise ValueError(f"Unknown sub command: {args.subcommand}. Check valid commands by running main.py --help")
+        raise ValueError(
+            f"Unknown sub command: {args.subcommand}. Check valid commands by running main.py --help"
+        )
 
 
 def parse_arguments():
-    parent_parser = argparse.ArgumentParser(description="PipeEval provides tools to run and assess differences between runs in pipelines")
-    parent_parser.add_argument(
-        "--version", action="version", version=f"%(prog)s ({__version__})"
+    parent_parser = argparse.ArgumentParser(
+        description="PipeEval provides tools to run and assess differences between runs in pipelines",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
+    parent_parser.add_argument("--version", action="version", version=f"%(prog)s ({__version__})")
     subparsers = parent_parser.add_subparsers(dest="subcommand")
 
-    run_parser = subparsers.add_parser("run", description="Runs a pipeline.")
+    run_parser = subparsers.add_parser(
+        "run",
+        description="Runs a pipeline.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     runner_add_arguments(run_parser)
 
-    eval_parser = subparsers.add_parser("eval", description="Takes two sets of results and generates a comparison")
+    eval_parser = subparsers.add_parser(
+        "eval",
+        description="Takes two sets of results and generates a comparison",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     eval_add_arguments(eval_parser)
 
-    vcf_parser = subparsers.add_parser("vcf", description="Compare two VCFs directly")
+    vcf_parser = subparsers.add_parser(
+        "vcf",
+        description="Compare two VCFs directly",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     vcf_add_arguments(vcf_parser)
 
     args = parent_parser.parse_args()

--- a/shared/util.py
+++ b/shared/util.py
@@ -2,7 +2,7 @@ from configparser import ConfigParser
 import logging
 from pathlib import Path
 from typing import Any, List, Optional
-
+	
 
 def load_config(logger: logging.Logger, parent_path: str, config_path: Optional[str]) -> ConfigParser:
     config = ConfigParser()

--- a/shared/util.py
+++ b/shared/util.py
@@ -2,7 +2,7 @@ from configparser import ConfigParser
 import logging
 from pathlib import Path
 from typing import Any, List, Optional
-	
+
 
 def load_config(logger: logging.Logger, parent_path: str, config_path: Optional[str]) -> ConfigParser:
     config = ConfigParser()

--- a/shared/vcf/main_functions.py
+++ b/shared/vcf/main_functions.py
@@ -194,6 +194,7 @@ def print_diff_score_info(
         variants_r2,
         is_sv,
         show_line_numbers,
+        annotation_info_keys,
         exclude_subscores=True,
     )
 
@@ -205,16 +206,12 @@ def print_diff_score_info(
         variants_r2,
         is_sv,
         show_line_numbers,
+        annotation_info_keys,
         exclude_subscores=False,
     )
 
     full_body = get_table(
-        run_id1,
-        run_id2,
         diff_scored_variants,
-        shared_variant_keys,
-        variants_r1,
-        variants_r2,
         is_sv,
         show_line_numbers,
         annotation_info_keys,
@@ -236,20 +233,14 @@ def print_diff_score_info(
         logger.info(row)
 
     above_thres_comparison_rows = get_table(
-        run_id1,
-        run_id2,
         diff_variants_above_thres,
-        shared_variant_keys,
-        variants_r1,
-        variants_r2,
         is_sv,
         show_line_numbers,
         annotation_info_keys,
     )
 
-    full_table = full_header + above_thres_comparison_rows
-
     if out_path_above_thres is not None:
+        full_table = [full_header] + above_thres_comparison_rows
         with open(str(out_path_above_thres), "w") as out_fh:
             for row in full_table:
                 print("\t".join(row), file=out_fh)

--- a/shared/vcf/score.py
+++ b/shared/vcf/score.py
@@ -13,9 +13,7 @@ def get_comparison_row(
 ) -> List[str]:
 
     if var1 != var2:
-        raise ValueError(
-            f"Must compare the same variant. This: {str(var1)} Other: {str(var2)}"
-        )
+        raise ValueError(f"Must compare the same variant. This: {str(var1)} Other: {str(var2)}")
 
     fields = [
         var1.chr,
@@ -44,6 +42,34 @@ def get_comparison_row(
     return fields
 
 
+def get_table_header(
+    run_id1: str,
+    run_id2: str,
+    shared_variant_keys: Set[str],
+    variants_r1: Dict[str, ScoredVariant],
+    variants_r2: Dict[str, ScoredVariant],
+    is_sv: bool,
+    show_line_numbers: bool,
+    exclude_subscores: bool
+):
+    first_shared_key = list(shared_variant_keys)[0]
+    header_fields = ["chr", "pos", "var"]
+    if is_sv:
+        header_fields.append("sv_len")
+    if show_line_numbers:
+        header_fields.append("line_numbers")
+    header_fields.extend([f"score_{run_id1}", f"score_{run_id2}", "score_diff_summary"])
+
+    if not exclude_subscores:
+        for sub_score in variants_r1[first_shared_key].sub_scores:
+            header_fields.append(f"r1_{sub_score}")
+        for sub_score in variants_r2[first_shared_key].sub_scores:
+            header_fields.append(f"r2_{sub_score}")
+    return header_fields
+    # rows = [header_fields]
+
+
+# FIXME: This one needs to be addressed
 def get_table(
     run_id1: str,
     run_id2: str,
@@ -53,21 +79,10 @@ def get_table(
     variants_r2: Dict[str, ScoredVariant],
     is_sv: bool,
     show_line_numbers: bool,
+    annotation_info_keys: List[str],
 ) -> List[List[str]]:
 
-    first_shared_key = list(shared_variant_keys)[0]
-    header_fields = ["chr", "pos", "var"]
-    if is_sv:
-        header_fields.append("sv_len")
-    if show_line_numbers:
-        header_fields.append("line_numbers")
-    header_fields.extend([f"score_{run_id1}", f"score_{run_id2}", "score_diff_summary"])
-
-    for sub_score in variants_r1[first_shared_key].sub_scores:
-        header_fields.append(f"r1_{sub_score}")
-    for sub_score in variants_r2[first_shared_key].sub_scores:
-        header_fields.append(f"r2_{sub_score}")
-    rows = [header_fields]
+    rows = []
 
     for variant in variants:
         comparison_fields = get_comparison_row(

--- a/shared/vcf/score.py
+++ b/shared/vcf/score.py
@@ -82,7 +82,6 @@ def get_table_header(
     return header_fields
 
 
-# FIXME: This one needs to be addressed
 def get_table(
     variants: List[DiffScoredVariant],
     is_sv: bool,

--- a/shared/vcf/score.py
+++ b/shared/vcf/score.py
@@ -8,6 +8,7 @@ def get_comparison_row(
     var2: ScoredVariant,
     show_sv_len: bool,
     show_line_numbers: bool,
+    annotation_info_keys: List[str],
     show_sub_scores: bool,
     show_sub_score_summary: bool,
 ) -> List[str]:
@@ -27,6 +28,17 @@ def get_comparison_row(
     if show_line_numbers:
         line_numbers = f"{var1.line_number}/{var2.line_number}"
         fields.append(line_numbers)
+
+    for annot_key in annotation_info_keys:
+        annot_value1 = var1.info_dict.get(annot_key) or ""
+        annot_value2 = var2.info_dict.get(annot_key) or ""
+
+        if annot_value1 == annot_value2:
+            annot = annot_value1
+        else:
+            annot = f"{annot_value1}/{annot_value2}"
+        fields.append(annot)
+
 
     fields.extend([var1.get_rank_score_str(), var2.get_rank_score_str()])
 
@@ -50,6 +62,7 @@ def get_table_header(
     variants_r2: Dict[str, ScoredVariant],
     is_sv: bool,
     show_line_numbers: bool,
+    annotation_info_keys: List[str],
     exclude_subscores: bool
 ):
     first_shared_key = list(shared_variant_keys)[0]
@@ -58,6 +71,7 @@ def get_table_header(
         header_fields.append("sv_len")
     if show_line_numbers:
         header_fields.append("line_numbers")
+    header_fields.extend(annotation_info_keys)
     header_fields.extend([f"score_{run_id1}", f"score_{run_id2}", "score_diff_summary"])
 
     if not exclude_subscores:
@@ -66,17 +80,11 @@ def get_table_header(
         for sub_score in variants_r2[first_shared_key].sub_scores:
             header_fields.append(f"r2_{sub_score}")
     return header_fields
-    # rows = [header_fields]
 
 
 # FIXME: This one needs to be addressed
 def get_table(
-    run_id1: str,
-    run_id2: str,
     variants: List[DiffScoredVariant],
-    shared_variant_keys: Set[str],
-    variants_r1: Dict[str, ScoredVariant],
-    variants_r2: Dict[str, ScoredVariant],
     is_sv: bool,
     show_line_numbers: bool,
     annotation_info_keys: List[str],
@@ -90,6 +98,7 @@ def get_table(
             variant.r2,
             show_sv_len=is_sv,
             show_line_numbers=show_line_numbers,
+            annotation_info_keys=annotation_info_keys,
             show_sub_scores=True,
             show_sub_score_summary=True,
         )

--- a/shared/vcf/vcf.py
+++ b/shared/vcf/vcf.py
@@ -1,3 +1,4 @@
+from logging import Logger
 from pathlib import Path
 from typing import Dict, List, Optional
 import re
@@ -67,7 +68,7 @@ class ScoredVariant:
     def get_basic_info(self) -> str:
         return f"{self.chr}:{self.pos} {self.get_trunc_ref()}/{self.get_trunc_alt()}"
 
-    def get_row(self, show_line_numbers: bool) -> List[str]:
+    def get_row(self, show_line_numbers: bool, additional_annotations: list[str]) -> List[str]:
         row = [self.chr, str(self.pos), self.get_trunc_ref(), self.get_trunc_alt()]
         if show_line_numbers:
             row.append(str(self.line_number))
@@ -75,6 +76,10 @@ class ScoredVariant:
             row.append(str(self.sv_length))
         if self.rank_score is not None:
             row.append(str(self.rank_score))
+        if len(additional_annotations):
+            for annot_key in additional_annotations:
+                annot_val = self.info_dict.get(annot_key)
+                row.append(annot_val if annot_val is not None else "")
         return row
 
     def __eq__(self, other: object) -> bool:

--- a/shared/vcf/vcf.py
+++ b/shared/vcf/vcf.py
@@ -1,4 +1,3 @@
-from logging import Logger
 from pathlib import Path
 from typing import Dict, List, Optional
 import re

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from typing import List
 from commands.vcf.main import main
 from pytest import LogCaptureFixture
 
@@ -17,6 +18,7 @@ def test_main(caplog: LogCaptureFixture, tmp_path: Path):
     run_id2 = "Run ID2"
     results = tmp_path / "results"
     results.mkdir()
+    annotations: List[str] = []
 
     with caplog.at_level(logging.INFO):
 
@@ -30,6 +32,7 @@ def test_main(caplog: LogCaptureFixture, tmp_path: Path):
             run_id1,
             run_id2,
             results,
+            annotations
         )
 
     assert len(caplog.records) > 0, "No logs were captured"


### PR DESCRIPTION
Include additional annotations from INFO-fields into the PipeEval output

```
$ python3 main.py vcf \
  -1 /home/jakob/data/hg002_1k.scored.vcf.gz \
  -2 /home/jakob/data/hg002_ma_1k.scored.vcf.gz \
  --annotations "Annotation,ModelScore" \
  --results testout2
```

```
INFO: chr    pos        var                                    line_numbers    Annotation       ModelScore                                                  score_hg002_1k    score_hg002_ma_1k    score_diff_summary                                                 
INFO: 1      5864452    C/A                                    920/1066        NPHP4            hg002:99/hg002:99/giab-trio-jw-extra_panels_to_create_yaml-bam:69       20                8                    Inheritance_Models:0/-12                                           
INFO: 1      1072326    G/A                                    474/486         RNF223           hg002:99/                                                   17                5                    Inheritance_Models:0/-12                                           
INFO: 1      3497126    G/A                                    805/890         MEGF6            hg002:99/                                                   13                1                    Inheritance_Models:0/-12
```

Close #72