### PR TITLE
Alkc/add priority cli arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2.2.1
 
+* Add `--priority` CLI arg to pipeeval runner, which overrides the config default and propagates down to run.csv
 * Fix baseline runs to pass nextflow config paths from the baseline repo instead of the primary repo.
 * Fix VCF index suffix for vcf-started runs
 * Add black to requirements-dev.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.2.1
 
-* Add `--priority` CLI arg to pipeeval runner, which overrides the config default and propagates down to run.csv
+* Add `--queue` CLI arg to pipeeval runner
 * Fix baseline runs to pass nextflow config paths from the baseline repo instead of the primary repo.
 * Fix VCF index suffix for vcf-started runs
 * Add black to requirements-dev.txt

--- a/commands/run/config/csv_templates/dna_const_single.csv
+++ b/commands/run/config/csv_templates/dna_const_single.csv
@@ -1,2 +1,2 @@
 clarity_sample_id,id,type,sex,assay,diagnosis,phenotype,group,father,mother,clarity_pool_id,platform,read1,read2,analysis,priority
-NA,<id proband>,proband,M,dev,<default_panel>,affected,<group>,,,NA,illumina,<read1 proband>,<read2 proband>,<analysis>,<priority>
+NA,<id proband>,proband,M,dev,<default_panel>,affected,<group>,,,NA,illumina,<read1 proband>,<read2 proband>,<analysis>,<queue>

--- a/commands/run/config/csv_templates/dna_const_single.csv
+++ b/commands/run/config/csv_templates/dna_const_single.csv
@@ -1,2 +1,2 @@
 clarity_sample_id,id,type,sex,assay,diagnosis,phenotype,group,father,mother,clarity_pool_id,platform,read1,read2,analysis,priority
-NA,<id proband>,proband,M,dev,<default_panel>,affected,<group>,,,NA,illumina,<read1 proband>,<read2 proband>,<analysis>,lowest
+NA,<id proband>,proband,M,dev,<default_panel>,affected,<group>,,,NA,illumina,<read1 proband>,<read2 proband>,<analysis>,<priority>

--- a/commands/run/config/csv_templates/dna_const_trio.csv
+++ b/commands/run/config/csv_templates/dna_const_trio.csv
@@ -1,4 +1,4 @@
 clarity_sample_id,id,type,sex,assay,diagnosis,phenotype,group,father,mother,clarity_pool_id,platform,read1,read2,analysis,priority
-NA,<id proband>,proband,<sex proband>,dev,<default_panel>,affected,<group>,<father>,<mother>,NA,illumina,<read1 proband>,<read2 proband>,<analysis>,lowest
-NA,<id mother>,mother,<sex mother>,dev,<default_panel>,unaffected,<group>,,,NA,illumina,<read1 mother>,<read2 mother>,<analysis>,lowest
-NA,<id father>,father,<sex father>,dev,<default_panel>,unaffected,<group>,,,NA,illumina,<read1 father>,<read2 father>,<analysis>,lowest
+NA,<id proband>,proband,<sex proband>,dev,<default_panel>,affected,<group>,<father>,<mother>,NA,illumina,<read1 proband>,<read2 proband>,<analysis>,<priority>
+NA,<id mother>,mother,<sex mother>,dev,<default_panel>,unaffected,<group>,,,NA,illumina,<read1 mother>,<read2 mother>,<analysis>,<priority>
+NA,<id father>,father,<sex father>,dev,<default_panel>,unaffected,<group>,,,NA,illumina,<read1 father>,<read2 father>,<analysis>,<priority>

--- a/commands/run/config/csv_templates/dna_const_trio.csv
+++ b/commands/run/config/csv_templates/dna_const_trio.csv
@@ -1,4 +1,4 @@
 clarity_sample_id,id,type,sex,assay,diagnosis,phenotype,group,father,mother,clarity_pool_id,platform,read1,read2,analysis,priority
-NA,<id proband>,proband,<sex proband>,dev,<default_panel>,affected,<group>,<father>,<mother>,NA,illumina,<read1 proband>,<read2 proband>,<analysis>,<priority>
-NA,<id mother>,mother,<sex mother>,dev,<default_panel>,unaffected,<group>,,,NA,illumina,<read1 mother>,<read2 mother>,<analysis>,<priority>
-NA,<id father>,father,<sex father>,dev,<default_panel>,unaffected,<group>,,,NA,illumina,<read1 father>,<read2 father>,<analysis>,<priority>
+NA,<id proband>,proband,<sex proband>,dev,<default_panel>,affected,<group>,<father>,<mother>,NA,illumina,<read1 proband>,<read2 proband>,<analysis>,<queue>
+NA,<id mother>,mother,<sex mother>,dev,<default_panel>,unaffected,<group>,,,NA,illumina,<read1 mother>,<read2 mother>,<analysis>,<queue>
+NA,<id father>,father,<sex father>,dev,<default_panel>,unaffected,<group>,,,NA,illumina,<read1 father>,<read2 father>,<analysis>,<queue>

--- a/commands/run/config/csv_templates/run.csv
+++ b/commands/run/config/csv_templates/run.csv
@@ -1,2 +1,2 @@
 clarity_sample_id,id,type,sex,assay,diagnosis,phenotype,group,father,mother,clarity_pool_id,platform,read1,read2,analysis,priority
-NA,hg002-rna,proband,M,dev,no_diagnosis,healthy,rna-test-master-fq,,,NA,illumina,/fs1/jakob/data/giab_hg002_rna/hg002_15M_R1.fastq.gz,/fs1/jakob/data/giab_hg002_rna/hg002_15M_R2.fastq.gz,cmd,<priority>
+NA,hg002-rna,proband,M,dev,no_diagnosis,healthy,rna-test-master-fq,,,NA,illumina,/fs1/jakob/data/giab_hg002_rna/hg002_15M_R1.fastq.gz,/fs1/jakob/data/giab_hg002_rna/hg002_15M_R2.fastq.gz,cmd,<queue>

--- a/commands/run/config/csv_templates/run.csv
+++ b/commands/run/config/csv_templates/run.csv
@@ -1,2 +1,2 @@
 clarity_sample_id,id,type,sex,assay,diagnosis,phenotype,group,father,mother,clarity_pool_id,platform,read1,read2,analysis,priority
-NA,hg002-rna,proband,M,dev,no_diagnosis,healthy,rna-test-master-fq,,,NA,illumina,/fs1/jakob/data/giab_hg002_rna/hg002_15M_R1.fastq.gz,/fs1/jakob/data/giab_hg002_rna/hg002_15M_R2.fastq.gz,cmd,lowest
+NA,hg002-rna,proband,M,dev,no_diagnosis,healthy,rna-test-master-fq,,,NA,illumina,/fs1/jakob/data/giab_hg002_rna/hg002_15M_R1.fastq.gz,/fs1/jakob/data/giab_hg002_rna/hg002_15M_R2.fastq.gz,cmd,<priority>

--- a/commands/run/file_helpers.py
+++ b/commands/run/file_helpers.py
@@ -71,6 +71,7 @@ def get_replace_map(
     sample_configs: List[SampleConfig],
     run_label: str,
     run_profile: RunProfileConfig,
+    run_priority: str,
 ) -> Dict[str, str]:
     """
     Used to insert values into template placeholders in the template csv.
@@ -85,6 +86,8 @@ def get_replace_map(
     replace_map = get_replace_map_special_rules(
         logger, run_label, sample_configs, starting_run_from, run_profile.case_type
     )
+
+    replace_map["<priority>"] = run_priority
 
     # Additional run profile attributes (analysis, default-panel etc)
     for attr, val in run_profile.items():
@@ -110,6 +113,7 @@ def get_csv(
     run_label: str,
     starting_run_from: str,
     csv_base: Path,
+    run_priority: str,
 ) -> str:
 
     csv_template_name = config.run_profile.csv_template
@@ -127,6 +131,7 @@ def get_csv(
         list(config.all_samples.values()),
         run_label,
         config.run_profile,
+        run_priority,
     )
 
     for i, row in enumerate(csv_body_rows):

--- a/commands/run/file_helpers.py
+++ b/commands/run/file_helpers.py
@@ -71,7 +71,6 @@ def get_replace_map(
     sample_configs: List[SampleConfig],
     run_label: str,
     run_profile: RunProfileConfig,
-    run_priority: str,
 ) -> Dict[str, str]:
     """
     Used to insert values into template placeholders in the template csv.
@@ -86,8 +85,6 @@ def get_replace_map(
     replace_map = get_replace_map_special_rules(
         logger, run_label, sample_configs, starting_run_from, run_profile.case_type
     )
-
-    replace_map["<priority>"] = run_priority
 
     # Additional run profile attributes (analysis, default-panel etc)
     for attr, val in run_profile.items():
@@ -113,7 +110,6 @@ def get_csv(
     run_label: str,
     starting_run_from: str,
     csv_base: Path,
-    run_priority: str,
 ) -> str:
 
     csv_template_name = config.run_profile.csv_template
@@ -131,8 +127,9 @@ def get_csv(
         list(config.all_samples.values()),
         run_label,
         config.run_profile,
-        run_priority,
     )
+
+    replace_map["<queue>"] = config.general_settings.queue
 
     for i, row in enumerate(csv_body_rows):
 

--- a/commands/run/main.py
+++ b/commands/run/main.py
@@ -62,7 +62,6 @@ def main(
     analysis: Optional[str],
     csv_base: Path,
     remote_name: str,
-    priority: Optional[str],
 ):
     logger.info(f"Preparing run, type: {run_profile}, data: {start_data}")
 
@@ -109,8 +108,6 @@ def main(
     assay = assay or ASSAY_PLACEHOLDER
     analysis = analysis or config.run_profile.run_profile
 
-    effective_priority = priority or config.general_settings.queue
-
     out_csv = results_dir / "run.csv"
     csv_content = get_csv(
         logger,
@@ -118,7 +115,6 @@ def main(
         run_label,
         start_data,
         csv_base,
-        effective_priority,
     )
 
     out_csv.write_text(csv_content)
@@ -130,7 +126,7 @@ def main(
             results_dir,
             config.general_settings.executor,
             config.general_settings.cluster,
-            effective_priority,
+            config.general_settings.queue,
             config.general_settings.singularity_version,
             config.general_settings.nextflow_version,
             config.general_settings.container,
@@ -385,6 +381,9 @@ def main_wrapper(args: argparse.Namespace):
         samples_path,
     )
 
+    if args.queue is not None:
+        config.general_settings.queue = args.queue
+    
     if args.silent:
         logger.setLevel(logging.WARNING)
 
@@ -420,7 +419,6 @@ def main_wrapper(args: argparse.Namespace):
             args.analysis,
             csv_base,
             args.remote,
-            args.priority,
         )
         logger.info("Now proceeding with checking out the --checkout")
     main(
@@ -440,7 +438,6 @@ def main_wrapper(args: argparse.Namespace):
         args.analysis,
         csv_base,
         args.remote,
-        args.priority,
     )
 
 
@@ -537,10 +534,10 @@ def add_arguments(parser: argparse.ArgumentParser):
         default="origin",
     )
     parser.add_argument(
-        "--priority",
+        "--queue",
         choices=["lowest", "low", "normal", "high", "highest"],
         default=None,
-        help="Override CSV priority; if omitted, keep template value.",
+        help="Override cluster queue/priority in config.",
     )
 
 

--- a/commands/run/main.py
+++ b/commands/run/main.py
@@ -62,6 +62,7 @@ def main(
     analysis: Optional[str],
     csv_base: Path,
     remote_name: str,
+    priority: Optional[str],
 ):
     logger.info(f"Preparing run, type: {run_profile}, data: {start_data}")
 
@@ -108,8 +109,17 @@ def main(
     assay = assay or ASSAY_PLACEHOLDER
     analysis = analysis or config.run_profile.run_profile
 
+    effective_priority = priority or config.general_settings.queue
+
     out_csv = results_dir / "run.csv"
-    csv_content = get_csv(logger, config, run_label, start_data, csv_base)
+    csv_content = get_csv(
+        logger,
+        config,
+        run_label,
+        start_data,
+        csv_base,
+        effective_priority,
+    )
 
     out_csv.write_text(csv_content)
 
@@ -120,7 +130,7 @@ def main(
             results_dir,
             config.general_settings.executor,
             config.general_settings.cluster,
-            config.general_settings.queue,
+            effective_priority,
             config.general_settings.singularity_version,
             config.general_settings.nextflow_version,
             config.general_settings.container,
@@ -410,6 +420,7 @@ def main_wrapper(args: argparse.Namespace):
             args.analysis,
             csv_base,
             args.remote,
+            args.priority,
         )
         logger.info("Now proceeding with checking out the --checkout")
     main(
@@ -429,6 +440,7 @@ def main_wrapper(args: argparse.Namespace):
         args.analysis,
         csv_base,
         args.remote,
+        args.priority,
     )
 
 
@@ -523,6 +535,12 @@ def add_arguments(parser: argparse.ArgumentParser):
         "--remote",
         help="Git remote from which to checkout if not present locally",
         default="origin",
+    )
+    parser.add_argument(
+        "--priority",
+        choices=["lowest", "low", "normal", "high", "highest"],
+        default=None,
+        help="Override CSV priority; if omitted, keep template value.",
     )
 
 


### PR DESCRIPTION
Closes #108 

# Added
- A `--queue` CLI arg to runner that overrides the config `queue`, if not supplied then falls back to the config 
- <queue> field added to the CSV templating 

# Changed
- Hard-coded priority fields in templates replaces with `<queue>` placeholder
